### PR TITLE
Issue68 - Improve the quality of the Panel App API Functions script

### DIFF
--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -39,11 +39,8 @@ Notes
 -----
 This module requires the `requests` library to fetch data from the PanelApp API.
 """
-import logging
 import requests
-
-# Set up logging configuration
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+from settings import logger
 
 class PanelAppError(Exception):
     """Custom exception for PanelApp errors."""
@@ -72,35 +69,35 @@ def get_response(panel_id):
 
     try:
         # Send the GET request to the API
-        logging.info("Sending request to Panel App API")
+        logger.info("Sending request to Panel App API")
         response = requests.get(url, timeout=10)
 
         # Raise an exception for any non-2xx HTTP status codes
         response.raise_for_status()
 
         # If the request was successful, return the response object
-        logging.info("Panel App API response successful")
+        logger.info("Panel App API response successful")
         return response
 
     except requests.exceptions.HTTPError as e:
         # Handle specific HTTP error codes
         if response.status_code == 404:
-            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
+            logger.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError(f"Panel {panel_id} not found.") from e
         if response.status_code == 500:
-            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
+            logger.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError("Server error: The server failed to process the request.") from e
         if response.status_code == 503:
-            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
+            logger.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError("Service unavailable: Please try again later.") from e
 
         # For other non-successful status codes, raise a general error
-        logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
+        logger.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
         raise PanelAppError(f"Error: {response.status_code} - {response.text}") from e
 
     except requests.exceptions.RequestException as e:
         # Catch all other types of request exceptions (network errors, etc.)
-        logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
+        logger.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
         # Raise a custom PanelAppError with a more general message
         raise PanelAppError(f"Failed to retrieve data for panel {panel_id}.") from e
 
@@ -132,7 +129,7 @@ def get_name_version(response):
         data = response.json()
 
         # Extract the required fields, defaulting to 'N/A' if not found
-        logging.info("Extracting data from JSON")
+        logger.info("Extracting data from JSON")
         return {
             "name": data.get("name", "N/A"),
             "version": data.get("version", "N/A"),
@@ -141,7 +138,7 @@ def get_name_version(response):
 
     except ValueError as e:
         # Log any errors encountered while parsing the JSON data
-        logging.error("Error parsing JSON: %s", e)
+        logger.error("Error parsing JSON: %s", e)
         # Raise a custom PanelAppError with a more descriptive message
         raise PanelAppError("Failed to parse panel data.") from e
 
@@ -175,18 +172,18 @@ def get_genes(response):
         data = response.json()
 
         # Extract the gene symbols from the 'genes' key
-        logging.info("Extracting data from JSON")
+        logger.info("Extracting data from JSON")
         return [gene["gene_data"]["gene_symbol"] for gene in data.get("genes", [])]
 
     except ValueError as e:
         # Log any errors encountered while parsing the JSON data
-        logging.error("Error parsing JSON: %s", e)
+        logger.error("Error parsing JSON: %s", e)
         # Raise a custom PanelAppError with a more descriptive message
         raise PanelAppError("Failed to parse gene data.") from e
 
     except requests.exceptions.HTTPError as e:
         # Log any errors encountered during the request
-        logging.error("Error fetching genes: %s", e)
+        logger.error("Error fetching genes: %s", e)
         # Re-raise the exception, as it will be handled further up the call stack
         raise
 
@@ -216,18 +213,18 @@ def get_response_old_panel_version(panel_pk, version):
 
     try:
         # Send the GET request to the API
-        logging.info("Sending request to Panel App API")
+        logger.info("Sending request to Panel App API")
         response = requests.get(url, timeout=10)
 
         # Raise an exception for any non-2xx HTTP status codes
         response.raise_for_status()
 
         # If the request was successful, return the response object
-        logging.info("Request to Panel App API was successful")
+        logger.info("Request to Panel App API was successful")
         return response
 
     except requests.exceptions.RequestException as e:
         # Log any errors encountered during the request
-        logging.error("Error fetching old panel version: %s", e)
+        logger.error("Error fetching old panel version: %s", e)
         # Raise a custom PanelAppError with a more descriptive message
         raise PanelAppError(f"Failed to retrieve version {version} of panel {panel_pk}.") from e

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -63,7 +63,7 @@ def get_response(panel_id):
     Raises
     ------
     PanelAppError
-        If the request fails or if a specific error occurs (404, 500, etc.).
+        If the request fails, times out, or if a specific error occurs (404, 500, etc.).
     """
     url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_id}"
 
@@ -78,6 +78,10 @@ def get_response(panel_id):
         # If the request was successful, return the response object
         logger.info("Panel App API response successful")
         return response
+    
+    except requests.exceptions.Timeout:
+        logger.error("Request timed out while fetching panel data for panel %s", panel_id)
+        raise PanelAppError(f"Timeout: Panel {panel_id} request exceeded the time limit. Please try again")
 
     except requests.exceptions.HTTPError as e:
         # Handle specific HTTP error codes
@@ -207,7 +211,7 @@ def get_response_old_panel_version(panel_pk, version):
     Raises
     ------
     PanelAppError
-        If the request fails or returns an error status code.
+        If the request fails, times out, or returns an error status code.
     """
     url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
 
@@ -222,6 +226,10 @@ def get_response_old_panel_version(panel_pk, version):
         # If the request was successful, return the response object
         logger.info("Request to Panel App API was successful")
         return response
+    
+    except requests.exceptions.Timeout:
+        logger.error("Request timed out while fetching panel data for panel with primary key %s", panel_pk)
+        raise PanelAppError(f"Timeout: Panel (primary key:{panel_pk}) request exceeded the time limit. Please try again")
 
     except requests.exceptions.RequestException as e:
         # Log any errors encountered during the request

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -25,15 +25,13 @@ get_response_old_panel_version(panel_pk, version)
     Fetches the response from the PanelApp API for a specific panel and version.
     Raises PanelAppError if the request fails or returns an error status code.
 
-get_old_gene_list(response)
-    Extracts the HGNC symbols from the genes list in the API response.
-    Raises PanelAppError if there is an error parsing the response JSON or
-    accessing required data, and KeyError if the expected data structure is
-    not found in the response.
-
 Example Usage
 -------------
 >>> response = get_response('R293')
+>>> panel_info = get_name_version(response)
+>>> genes = get_genes(response)
+OR
+>>> response = get_response_old_panel_version(panel_pk, version)
 >>> panel_info = get_name_version(response)
 >>> genes = get_genes(response)
 

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -237,7 +237,7 @@ def get_response_old_panel_version(panel_pk, version):
         logger.error("Request timed out while fetching panel data for panel"
                      "with primary key %s", panel_pk)
         # Raise a custom PanelAppError with a descriptive message
-        raise PanelAppError(f"Panel {panel_pk} request exceeded the time limit. "
+        raise PanelAppError(f"Timeout: Panel {panel_pk} request exceeded the time limit. "
                             "Please try again") from e
 
     except requests.exceptions.RequestException as e:

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -78,9 +78,12 @@ def get_response(panel_id):
         # If the request was successful, return the response object
         logger.info("Panel App API response successful")
         return response
-    
+
+    # Handle errors if the API request times out
     except requests.exceptions.Timeout:
+        # Log error if the API request times out
         logger.error("Request timed out while fetching panel data for panel %s", panel_id)
+        # Raise a custom PanelAppError with a descriptive message
         raise PanelAppError(f"Timeout: Panel {panel_id} request exceeded the time limit. Please try again")
 
     except requests.exceptions.HTTPError as e:
@@ -226,9 +229,12 @@ def get_response_old_panel_version(panel_pk, version):
         # If the request was successful, return the response object
         logger.info("Request to Panel App API was successful")
         return response
-    
+
+    # Handle errors if the API request times out
     except requests.exceptions.Timeout:
+        # Log error if the API request times out
         logger.error("Request timed out while fetching panel data for panel with primary key %s", panel_pk)
+        # Raise a custom PanelAppError with a descriptive message
         raise PanelAppError(f"Timeout: Panel (primary key:{panel_pk}) request exceeded the time limit. Please try again")
 
     except requests.exceptions.RequestException as e:

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -160,7 +160,7 @@ def get_genes(response):
     Returns
     -------
     list
-        A list of gene symbols (strings).
+        A list of HGNC symbols for each gene in the response data.
 
     Raises
     ------
@@ -218,6 +218,7 @@ def get_response_old_panel_version(panel_pk, version):
 
     try:
         # Send the GET request to the API
+        logging.info("Sending request to Panel App API")
         response = requests.get(url, timeout=10)
 
         # Raise an exception for any non-2xx HTTP status codes
@@ -232,45 +233,3 @@ def get_response_old_panel_version(panel_pk, version):
         logging.error("Error fetching old panel version: %s", e)
         # Raise a custom PanelAppError with a more descriptive message
         raise PanelAppError(f"Failed to retrieve version {version} of panel {panel_pk}.") from e
-
-
-def get_old_gene_list(response):
-    """
-    Extracts the HGNC symbols from the genes list in the API response.
-
-    Parameters
-    ----------
-    response : requests.Response
-        The response object returned from the PanelApp API.
-
-    Returns
-    -------
-    list
-        A list of HGNC symbols for each gene in the response data.
-
-    Raises
-    ------
-    PanelAppError
-        If there is an error parsing the response JSON or accessing required data.
-    KeyError
-        If the expected data structure is not found in the response.
-    """
-    try:
-        # Parse the JSON data from the response
-        data = response.json()
-
-        # Extract the HGNC symbols from the 'genes' data
-        logging.info("Extracting gene symbols from JSON")
-        return [gene['gene_data']['hgnc_symbol'] for gene in data["genes"]]
-
-    except ValueError as e:
-        # Log any errors encountered while parsing the JSON data
-        logging.error("Error parsing gene list JSON: %s", e)
-        # Raise a custom PanelAppError with a more descriptive message
-        raise PanelAppError("Failed to parse gene list data.") from e
-
-    except KeyError as e:
-        # Log any missing required data in the response
-        logging.error("Missing required data in response: %s", e)
-        # Raise a custom PanelAppError with a more descriptive message
-        raise PanelAppError("Response missing required gene data.") from e

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -80,11 +80,12 @@ def get_response(panel_id):
         return response
 
     # Handle errors if the API request times out
-    except requests.exceptions.Timeout:
+    except requests.exceptions.Timeout as e:
         # Log error if the API request times out
         logger.error("Request timed out while fetching panel data for panel %s", panel_id)
         # Raise a custom PanelAppError with a descriptive message
-        raise PanelAppError(f"Timeout: Panel {panel_id} request exceeded the time limit. Please try again")
+        raise PanelAppError(f"Timeout: Panel {panel_id} request exceeded the time limit. "
+                            "Please try again") from e
 
     except requests.exceptions.HTTPError as e:
         # Handle specific HTTP error codes
@@ -231,11 +232,13 @@ def get_response_old_panel_version(panel_pk, version):
         return response
 
     # Handle errors if the API request times out
-    except requests.exceptions.Timeout:
+    except requests.exceptions.Timeout as e:
         # Log error if the API request times out
-        logger.error("Request timed out while fetching panel data for panel with primary key %s", panel_pk)
+        logger.error("Request timed out while fetching panel data for panel"
+                     "with primary key %s", panel_pk)
         # Raise a custom PanelAppError with a descriptive message
-        raise PanelAppError(f"Timeout: Panel (primary key:{panel_pk}) request exceeded the time limit. Please try again")
+        raise PanelAppError(f"Panel {panel_pk} request exceeded the time limit. "
+                            "Please try again") from e
 
     except requests.exceptions.RequestException as e:
         # Log any errors encountered during the request

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -75,7 +75,7 @@ def get_response(panel_id):
     try:
         # Send the GET request to the API
         logging.info("Sending request to Panel App API")
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
 
         # Raise an exception for any non-2xx HTTP status codes
         response.raise_for_status()
@@ -218,7 +218,7 @@ def get_response_old_panel_version(panel_pk, version):
 
     try:
         # Send the GET request to the API
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
 
         # Raise an exception for any non-2xx HTTP status codes
         response.raise_for_status()

--- a/accessories/panel_app_api_functions.py
+++ b/accessories/panel_app_api_functions.py
@@ -74,29 +74,35 @@ def get_response(panel_id):
 
     try:
         # Send the GET request to the API
+        logging.info("Sending request to Panel App API")
         response = requests.get(url)
 
         # Raise an exception for any non-2xx HTTP status codes
         response.raise_for_status()
 
         # If the request was successful, return the response object
+        logging.info("Panel App API response successful")
         return response
 
     except requests.exceptions.HTTPError as e:
         # Handle specific HTTP error codes
         if response.status_code == 404:
+            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError(f"Panel {panel_id} not found.") from e
         if response.status_code == 500:
+            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError("Server error: The server failed to process the request.") from e
         if response.status_code == 503:
+            logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
             raise PanelAppError("Service unavailable: Please try again later.") from e
 
         # For other non-successful status codes, raise a general error
+        logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
         raise PanelAppError(f"Error: {response.status_code} - {response.text}") from e
 
     except requests.exceptions.RequestException as e:
         # Catch all other types of request exceptions (network errors, etc.)
-        logging.error("Request failed: %s", e)
+        logging.error("Error occurred while fetching panel data for panel %s: %s", panel_id, e)
         # Raise a custom PanelAppError with a more general message
         raise PanelAppError(f"Failed to retrieve data for panel {panel_id}.") from e
 
@@ -128,6 +134,7 @@ def get_name_version(response):
         data = response.json()
 
         # Extract the required fields, defaulting to 'N/A' if not found
+        logging.info("Extracting data from JSON")
         return {
             "name": data.get("name", "N/A"),
             "version": data.get("version", "N/A"),
@@ -170,6 +177,7 @@ def get_genes(response):
         data = response.json()
 
         # Extract the gene symbols from the 'genes' key
+        logging.info("Extracting data from JSON")
         return [gene["gene_data"]["gene_symbol"] for gene in data.get("genes", [])]
 
     except ValueError as e:
@@ -216,6 +224,7 @@ def get_response_old_panel_version(panel_pk, version):
         response.raise_for_status()
 
         # If the request was successful, return the response object
+        logging.info("Request to Panel App API was successful")
         return response
 
     except requests.exceptions.RequestException as e:
@@ -251,6 +260,7 @@ def get_old_gene_list(response):
         data = response.json()
 
         # Extract the HGNC symbols from the 'genes' data
+        logging.info("Extracting gene symbols from JSON")
         return [gene['gene_data']['hgnc_symbol'] for gene in data["genes"]]
 
     except ValueError as e:

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -1,7 +1,7 @@
 import responses
 import pytest
 import requests
-from panel_app_api_functions import get_response, get_name_version, get_genes
+from accessories.panel_app_api_functions import get_response, get_name_version, get_genes
 
 
 class TestGetResponse:
@@ -127,7 +127,7 @@ class TestGetResponse:
         responses.add(responses.GET, url, status=404)
 
         # Test that a corresponding exception is raised.
-        with pytest.raises(Exception, match=f"Error: Panel {panel_id} not found."):
+        with pytest.raises(Exception, match=f"Panel {panel_id} not found."):
             get_response(panel_id)
 
 
@@ -183,9 +183,9 @@ class TestGetNameVersion:
         
         # Generates the mock response
         response = requests.get(url)
-        
-        # Tests that the response returns None in this function
-        assert get_name_version(response) is None
+        result = get_name_version(response)
+        # Tests that the response returns blank dict in this function
+        assert result == {'name': 'N/A', 'panel_pk': 'N/A', 'version': 'N/A'}
     
     
     def test_success(self):
@@ -200,97 +200,20 @@ class TestGetNameVersion:
         responses.add(
             responses.GET, url, status=200,
             json={
-                    "id": 1208,
-                    "hash_id": None,
-                    "name": "Agammaglobulinaemia with absent BTK expression",
-                    "disease_group": "",
-                    "disease_sub_group": "",
-                    "status": "public",
-                    "version": "1.1",
-                    "version_created": "2023-09-14T12:48:53.836747Z",
-                    "relevant_disorders": [
-                        "R233"
-                    ],
-                    "stats": {
-                        "number_of_genes": 1,
-                        "number_of_strs": 0,
-                        "number_of_regions": 0
-                    },
-                    "types": [
-                        {
-                        "name": "GMS Rare Disease",
-                        "slug": "gms-rare-disease",
-                        "description": "This panel type is used for GMS panels that are not virtual (i.e. could be a wet lab test)"
-                        },
-                        {
-                        "name": "GMS signed-off",
-                        "slug": "gms-signed-off",
-                        "description": "This panel has undergone review by a NHSE GMS disease specialist group and processes to be signed-off for use within the GMS."
-                        }
-                    ],
-                    "genes": [
-                        {
-                        "gene_data": {
-                            "alias": [
-                            "ATK",
-                            "XLA",
-                            "PSCTK1"
-                            ],
-                            "biotype": "protein_coding",
-                            "hgnc_id": "HGNC:1133",
-                            "gene_name": "Bruton tyrosine kinase",
-                            "omim_gene": [
-                            "300300"
-                            ],
-                            "alias_name": [
-                            "Bruton's tyrosine kinase"
-                            ],
-                            "gene_symbol": "BTK",
-                            "hgnc_symbol": "BTK",
-                            "hgnc_release": "2017-11-03",
-                            "ensembl_genes": {
-                            "GRch37": {
-                                "82": {
-                                "location": "X:100604435-100641183",
-                                "ensembl_id": "ENSG00000010671"
-                                }
-                            },
-                            "GRch38": {
-                                "90": {
-                                "location": "X:101349447-101390796",
-                                "ensembl_id": "ENSG00000010671"
-                                }
-                            }
-                            },
-                            "hgnc_date_symbol_changed": "1986-01-01"
-                        },
-                        "entity_type": "gene",
-                        "entity_name": "BTK",
-                        "confidence_level": "3",
-                        "penetrance": None,
-                        "mode_of_pathogenicity": "",
-                        "publications": [],
-                        "evidence": [
-                            "NHS GMS",
-                            "Expert Review Green"
-                        ],
-                        "phenotypes": [],
-                        "mode_of_inheritance": "X-LINKED: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)",
-                        "tags": [],
-                        "transcript": None
-                        }
-                    ],
-                    "strs": [],
-                    "regions": []
-                    }
+                "id": 1208,
+                "name": "Agammaglobulinaemia with absent BTK expression",
+                "version": "1.1"
+            }
         )
         
         # Generates the mock response
         response = requests.get(url)
+        result = get_name_version(response)
         
         # Tests that a successful api response creates a panel name and version OK
-        assert get_name_version(response) == {
+        assert result == {
             "name": "Agammaglobulinaemia with absent BTK expression",
+            "panel_pk": 1208,
             "version": "1.1"
             }
         

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -1,18 +1,19 @@
 import responses
 import pytest
 import requests
-from accessories.panel_app_api_functions import get_response, get_name_version, get_genes
+from accessories.panel_app_api_functions import get_response, get_name_version, get_genes, get_response_old_panel_version, get_old_gene_list 
+from accessories.panel_app_api_functions import PanelAppError
 
 
 class TestGetResponse:
-    
+
     def test_get_response_success(self):
         """
         Tests successful api requests generates both a correct json, and a 200 status code
         """
-        
+
         panel_id = "R233"
-        
+
         # This is real data from the api from panel R233
         # It is only one gene so was chosen for brevity.
         # The null values were changed for None for python compatibility.
@@ -104,10 +105,10 @@ class TestGetResponse:
                         "strs": [],
                         "regions": []
                         }
-        
+
         # Runs the function to access the API
         response = get_response(panel_id)
-        
+
         # Performs the test that the response code is successful
         assert response.status_code == 200
         # Performs the test that the json accessed matches the one above
@@ -119,10 +120,10 @@ class TestGetResponse:
         """
         Tests for 404 errors
         """
-        
+
         panel_id = "R293"
         url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_id}"
-        
+
         # If a request is made, generate a mock 404 Not Found response
         responses.add(responses.GET, url, status=404)
 
@@ -138,10 +139,10 @@ class TestGetResponse:
         """
         panel_id = "R293"
         url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_id}"
-        
+
         # If a request is made, generate a mock 500 Server Error response
         responses.add(responses.GET, url, status=500)
-        
+
         # Test that a corresponding exception is raised.
         with pytest.raises(Exception, match="Server error: The server failed to process the request."):
             get_response(panel_id)
@@ -154,7 +155,7 @@ class TestGetResponse:
         """
         panel_id = "R293"
         url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_id}"
-        
+
         # If a request is made, generate a mock 503 Service Unavailable response
         responses.add(responses.GET, url, status=503)
 
@@ -170,7 +171,7 @@ class TestGetNameVersion:
         """
         Tests that non 200 codes return None
         """
-        
+
         # This URL is irrelevant since we're mocking the response
         url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/R233"
 
@@ -180,19 +181,19 @@ class TestGetNameVersion:
             json={"detail": "Not found."},
             status=404
         )
-        
+
         # Generates the mock response
         response = requests.get(url)
         result = get_name_version(response)
         # Tests that the response returns blank dict in this function
         assert result == {'name': 'N/A', 'panel_pk': 'N/A', 'version': 'N/A'}
-    
-    
+
+    @responses.activate
     def test_success(self):
         """
         Tests a successful api response
         """
-        
+
         # This URL is irrelevant since we're mocking the response
         url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/R233"
 
@@ -205,24 +206,224 @@ class TestGetNameVersion:
                 "version": "1.1"
             }
         )
-        
+
         # Generates the mock response
         response = requests.get(url)
         result = get_name_version(response)
-        
+
         # Tests that a successful api response creates a panel name and version OK
         assert result == {
             "name": "Agammaglobulinaemia with absent BTK expression",
             "panel_pk": 1208,
             "version": "1.1"
             }
-        
-        
+
+
 class TestGetGenes:
-    
     @responses.activate
-    def test_response(self):
-        ...
-    
-    def test_succcess(self):
-        ...
+    def test_get_genes_success(self):
+        """
+        Test that the get_genes function returns a list of gene symbols
+        when the API response is successful.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/R233"
+        responses.add(
+            responses.GET, url,
+            json={"genes": [{"gene_data": {"gene_symbol": "BRCA1"}}, {"gene_data": {"gene_symbol": "BRCA2"}}]},
+            status=200
+        )
+
+        response = requests.get(url)
+        genes = get_genes(response)
+
+        assert genes == ["BRCA1", "BRCA2"]
+
+    @responses.activate
+    def test_get_genes_http_error(self):
+        """
+        Test that the get_genes function raises a requests.exceptions.HTTPError
+        when the API response has a non-2xx status code.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/R233"
+        responses.add(
+            responses.GET, url,
+            json={"detail": "Not found."},
+            status=404
+        )
+
+        response = requests.get(url)
+        with pytest.raises(requests.exceptions.HTTPError):
+            get_genes(response)
+
+    @responses.activate
+    def test_get_genes_json_error(self):
+        """
+        Test that the get_genes function raises a PanelAppError
+        when there is an error parsing the JSON data.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/R233"
+        responses.add(
+            responses.GET, url,
+            body='{"genes": [invalid_json]}',
+            status=200
+        )
+
+        response = requests.get(url)
+        with pytest.raises(PanelAppError):
+            get_genes(response)
+
+
+class TestGetResponseOldPanelVersion:
+    @responses.activate
+    def test_successful_response(self):
+        """
+        Test that the function returns the response object when the request is successful.
+        """
+        panel_pk = "123"
+        version = "2.0"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
+
+        # Mock a successful response
+        responses.add(
+            responses.GET, url,
+            json={"status": "success"},
+            status=200
+        )
+
+        response = get_response_old_panel_version(panel_pk, version)
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+    @responses.activate
+    def test_404_error(self):
+        """
+        Test that the function raises PanelAppError for a 404 Not Found response.
+        """
+        panel_pk = "999"
+        version = "1.0"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
+
+        # Mock a 404 Not Found response
+        responses.add(
+            responses.GET, url,
+            status=404
+        )
+
+        with pytest.raises(PanelAppError, match=f"Failed to retrieve version {version} of panel {panel_pk}."):
+            get_response_old_panel_version(panel_pk, version)
+
+    @responses.activate
+    def test_server_error(self):
+        """
+        Test that the function raises PanelAppError for a 500 Internal Server Error response.
+        """
+        panel_pk = "123"
+        version = "3.0"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
+        
+        # Mock a 500 Internal Server Error response
+        responses.add(
+            responses.GET, url,
+            status=500
+        )
+
+        with pytest.raises(PanelAppError, match=f"Failed to retrieve version {version} of panel {panel_pk}."):
+            get_response_old_panel_version(panel_pk, version)
+
+    @responses.activate
+    def test_network_error(self):
+        """
+        Test that the function raises PanelAppError for network-related issues.
+        """
+        panel_pk = "456"
+        version = "1.1"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
+
+        # Simulate a connection error
+        responses.add(
+            responses.GET, url,
+            body=responses.ConnectionError("Network error occurred.")
+        )
+
+        with pytest.raises(PanelAppError, match=f"Failed to retrieve version {version} of panel {panel_pk}."):
+            get_response_old_panel_version(panel_pk, version)
+
+
+class TestGetOldGeneList:
+    @responses.activate
+    def test_successful_gene_list_extraction(self):
+        """
+        Test that the function correctly extracts HGNC symbols when the response is valid.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/123/?version=1.0"
+        mock_response = {
+            "genes": [
+                {"gene_data": {"hgnc_symbol": "BRCA1"}},
+                {"gene_data": {"hgnc_symbol": "BRCA2"}},
+                {"gene_data": {"hgnc_symbol": "TP53"}}
+            ]
+        }
+        responses.add(
+            responses.GET, url,
+            json=mock_response,
+            status=200
+        )
+
+        response = requests.get(url)
+        gene_list = get_old_gene_list(response)
+        
+        assert gene_list == ["BRCA1", "BRCA2", "TP53"]
+
+    @responses.activate
+    def test_missing_genes_key(self):
+        """
+        Test that the function raises PanelAppError if the 'genes' key is missing in the response.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/123/?version=1.0"
+        mock_response = {"other_data": []}
+        responses.add(
+            responses.GET, url,
+            json=mock_response,
+            status=200
+        )
+
+        response = requests.get(url)
+        with pytest.raises(PanelAppError, match="Response missing required gene data."):
+            get_old_gene_list(response)
+
+    @responses.activate
+    def test_invalid_json(self):
+        """
+        Test that the function raises PanelAppError if the response JSON is invalid.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/123/?version=1.0"
+        responses.add(
+            responses.GET, url,
+            body='invalid_json',
+            status=200
+        )
+
+        response = requests.get(url)
+        with pytest.raises(PanelAppError, match="Failed to parse gene list data."):
+            get_old_gene_list(response)
+
+    @responses.activate
+    def test_missing_hgnc_symbol(self):
+        """
+        Test that the function raises PanelAppError if 'hgnc_symbol' is missing in the gene data.
+        """
+        url = "https://panelapp.genomicsengland.co.uk/api/v1/panels/123/?version=1.0"
+        mock_response = {
+            "genes": [
+                {"gene_data": {"another_key": "BRCA1"}},
+            ]
+        }
+        responses.add(
+            responses.GET, url,
+            json=mock_response,
+            status=200
+        )
+
+        response = requests.get(url)
+        with pytest.raises(PanelAppError, match="Response missing required gene data."):
+            get_old_gene_list(response)

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -131,7 +131,7 @@ class TestGetResponse:
         )
 
         # Test that a corresponding exception is raised with the correct message
-        with pytest.raises(Exception, match="Timeout: Panel R293 request exceeded the time limit."):
+        with pytest.raises(PanelAppError, match="Timeout: Panel R293 request exceeded the time limit."):
             get_response(panel_id)
 
 
@@ -405,7 +405,7 @@ class TestGetResponseOldPanelVersion:
         )
 
         # Test that the correct exception is raised with the expected message
-        with pytest.raises(Exception, match=f"Timeout: Panel \\(primary key:{panel_pk}\\) request exceeded the time limit. Please try again"):
+        with pytest.raises(PanelAppError, match=f"Timeout: Panel {panel_pk} request exceeded the time limit. Please try again"):
             get_response_old_panel_version(panel_pk, version)
 
     @responses.activate

--- a/test/test_panelapp.py
+++ b/test/test_panelapp.py
@@ -113,6 +113,26 @@ class TestGetResponse:
         assert response.status_code == 200
         # Performs the test that the json accessed matches the one above
         assert response.json() == real_json
+    
+    
+    @responses.activate
+    def test_get_response_timeout(self):
+        """
+        Tests for Timeout Errors
+        """
+        panel_id = "R293"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_id}"
+
+        # Simulate a timeout by raising a `ConnectTimeout` when the request is made
+        responses.add(
+            responses.GET,
+            url,
+            body=requests.exceptions.ConnectTimeout(),
+        )
+
+        # Test that a corresponding exception is raised with the correct message
+        with pytest.raises(Exception, match="Timeout: Panel R293 request exceeded the time limit."):
+            get_response(panel_id)
 
 
     @responses.activate
@@ -366,6 +386,27 @@ class TestGetResponseOldPanelVersion:
         response = get_response_old_panel_version(panel_pk, version)
         assert response.status_code == 200
         assert response.json() == {"status": "success"}
+    
+    
+    @responses.activate
+    def test_get_response_old_panel_version_timeout(self):
+        """
+        Tests for Timeout Errors in get_response_old_panel_version
+        """
+        panel_pk = "123"
+        version = "1.0"
+        url = f"https://panelapp.genomicsengland.co.uk/api/v1/panels/{panel_pk}/?version={version}"
+
+        # Simulate a timeout by raising a `ConnectTimeout` when the request is made
+        responses.add(
+            responses.GET,
+            url,
+            body=requests.exceptions.ConnectTimeout(),
+        )
+
+        # Test that the correct exception is raised with the expected message
+        with pytest.raises(Exception, match=f"Timeout: Panel \\(primary key:{panel_pk}\\) request exceeded the time limit. Please try again"):
+            get_response_old_panel_version(panel_pk, version)
 
     @responses.activate
     def test_404_error(self):


### PR DESCRIPTION
For #18 and Sprint 3 I've brought the panel app api functions up to a higher quality

1. Improved Error handling
2. PEP8 compliant according to pylint
![image](https://github.com/user-attachments/assets/c8e6cdfc-f165-4a7c-a9d4-e3cf65b6a21e)
4. In line commenting
5. Doc strings in Numpy format
6. Top level documentation in Numpy format
7. Logging added to key bits of commands, and errors. I know we said we wouldn't for accessories files, but this seems OK to me after considering it, very few logging lines will be run from these commands anyway.
8. Created tests with 100% pass rate:
![image](https://github.com/user-attachments/assets/a5e658e4-b608-4638-bf59-e26dbb6f5bc7)
9. Created tests with 100% coverage for panel_app_api_functions.py according to "coverage report -m"
![image](https://github.com/user-attachments/assets/4cd38331-e8f1-47e3-9627-9ccdb462e792)


I also added an additional function that will contribute towards #52 #57 (Duplicate issue) to be able to compare gene lists for user story #56 . The function is:
- get_response_old_panel_version which uses a different API end point to get old versions of a panel

The above required using the database primary key for the panel, rather than the R number, so this was also added as an output of get_genes 

Creation of a logger is temporarily in this file to be removed once I tackle loggers more fully. 
README.md not added to. Not sure if it will need to go in there at all, but for now waiting for Ash to redo the README.